### PR TITLE
Fixar varningarna för /public

### DIFF
--- a/src/components/MainMenu.jsx
+++ b/src/components/MainMenu.jsx
@@ -16,7 +16,7 @@ export default function MainMenu() {
             <Navbar.Toggle aria-controls={`offcanvasNavbar-expand-${expand}`} />
             <Navbar.Brand href="/StartView">
               <div className="h6 text-secondary custom-text-logo text-center m-0">
-                <img src="/public/img/logo/filmvisarna-logo-icon.png" className="d-block custom-logo-navbar mx-auto"></img>
+                <img src="/img/logo/filmvisarna-logo-icon.png" className="d-block custom-logo-navbar mx-auto"></img>
                 Filmvisarna
               </div>
             </Navbar.Brand>

--- a/src/sass/load-and-modify-bootstrap.scss
+++ b/src/sass/load-and-modify-bootstrap.scss
@@ -30,7 +30,7 @@ h1, h2, h3, h4, h5 {
 }
 
 body {
-  background-image: url("/public/img/bg/bg-1.jpg");
+  background-image: url("/img/bg/bg-1.jpg");
   background-repeat: no-repeat;
   background-size: contain;
 }

--- a/src/views/AboutView.jsx
+++ b/src/views/AboutView.jsx
@@ -9,7 +9,7 @@ const AboutView = () => {
         <Container >
             <Row> 
                 <Col className='mx-auto text-center'>
-                    <Image src="public\img\Aboutposter\Aboutpic.jpg" thumbnail />
+                    <Image src="/img/Aboutposter/Aboutpic.jpg" thumbnail />
                 </Col>
             </Row>
             <Row>

--- a/src/views/RegisterView.jsx
+++ b/src/views/RegisterView.jsx
@@ -11,7 +11,7 @@ export default function RegisterView() {
         <>
             <Container>
                 <Col className="mx-auto text-center">
-                    <Image src="/public/img/logo/filmvisarna-logo-icon.png" roundedCircle style={{ width: '100px', height: '100px' }} />
+                    <Image src="/img/logo/filmvisarna-logo-icon.png" roundedCircle style={{ width: '100px', height: '100px' }} />
                 </Col>
                 <h1 className="text-center">Bli Medlem</h1>
                 <Form className="mx-auto">


### PR DESCRIPTION
Löser varningarna:
files in the public directory are served at the root path.
Instead of /public/img/bg/bg-1.jpg, use /img/bg/bg-1.jpg.
files in the public directory are served at the root path.
Instead of /public/img/logo/filmvisarna-logo-icon.png, use /img/logo/filmvisarna-logo-icon.png.
files in the public directory are served at the root path.
Instead of /public/img/Aboutposter/Aboutpic.jpg, use /img/Aboutposter/Aboutpic.jpg.
files in the public directory are served at the root path.
Instead of /public/img/Aboutposter/Aboutpic.jpg, use /img/Aboutposter/Aboutpic.jpg. (x2)
files in the public directory are served at the root path.
Instead of /public/img/bg/bg-1.jpg, use /img/bg/bg-1.jpg.
files in the public directory are served at the root path.
Instead of /public/img/logo/filmvisarna-logo-icon.png, use /img/logo/filmvisarna-logo-icon.png.