### PR TITLE
Generic base controller

### DIFF
--- a/WebReact/src/App.jsx
+++ b/WebReact/src/App.jsx
@@ -18,7 +18,7 @@ export default function App() {
     (async () => {
       setGlobals({
         ...globals,
-        movies: await get('movies')
+        movies: await get('movies/detailed')
       });
     })();
   }, []);

--- a/WebReact/src/views/ConfirmedView.jsx
+++ b/WebReact/src/views/ConfirmedView.jsx
@@ -9,7 +9,7 @@ const ConfirmedView = () => {
 
   async function fetchBooking() {
     try {
-      var booking = await get('bookings/' + bookingId);
+      var booking = await get('bookings/detailed/' + bookingId);
       return booking;
     } catch (err) {
       console.log(err);

--- a/WebReact/src/views/MovieView.jsx
+++ b/WebReact/src/views/MovieView.jsx
@@ -15,7 +15,7 @@ function MovieView() {
 		(async () => {
 			setScreenings({
 				...screenings,
-				screenings: await get(`screenings/mov${movieId}`)
+				screenings: await get(`screenings/movie/${movieId}`)
 			});
 		})();
 	}, []);

--- a/WebReact/src/views/TheaterView.jsx
+++ b/WebReact/src/views/TheaterView.jsx
@@ -24,9 +24,9 @@ const TheaterView = () => {
 
     async function fetchAndInit() {
         try {
-            var screeningJson = await get('screenings/' + screeningId);
+            var screeningJson = await get('screenings/bookedseats/' + screeningId);
             setJsonScreening(screeningJson);
-            var theaterJson = await get('theaters/' + screeningJson.theaterId);
+            var theaterJson = await get('theaters/detailed/' + screeningJson.theaterId);
             return theaterJson;
         } catch (err) {
             console.log(err);
@@ -37,7 +37,7 @@ const TheaterView = () => {
     const sendRequest = async () => {
         /** Här borde göras kontroller innan vi skickar iväg och kolla att resultatet är ok */
         var booking = createBookingJson();
-        var result = await post('bookings/', booking);
+        var result = await post('bookings/detailed', booking);
         //console.log("Last check: "  + result.bookingId );
         //setResponse(result); //Onödig?
         window.location.href = '/ConfirmedView/' + result.bookingId;

--- a/webapi/Controllers/BookingsController.cs
+++ b/webapi/Controllers/BookingsController.cs
@@ -5,21 +5,18 @@ using webapi.Data;
 using webapi.Entities;
 using webapi.ViewModels;
 
-namespace YourNamespace.Controllers
+namespace webapi.Controllers
 {
+   
     [Route("api/[controller]")]
     [ApiController]
-    public class BookingsController : ControllerBase
+    public class BookingsController : GenericController<Booking>
     {
-        private readonly FilmvisarnaContext _context;
-
-        public BookingsController(FilmvisarnaContext context)
+        public BookingsController(FilmvisarnaContext context) : base(context)
         {
-            _context = context;
         }
-
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetBooking(int id)
+        [HttpGet("detailed/{id}")]
+        public async Task<IActionResult> GetDetailedBookingById(int id)
         {
             var result = await _context.bookings
                 .Where(b => b.Id == id)
@@ -53,8 +50,9 @@ namespace YourNamespace.Controllers
 
             return Ok(result);
         }
-        [HttpPost()]
-        public async Task<IActionResult> Post(MakeBookingModel model)
+        
+        [HttpPost("detailed")]
+        public async Task<IActionResult> PostBookingModel(MakeBookingModel model)
         {
             if (await _context.users.SingleOrDefaultAsync(b => b.EmailAdress == model.EmailAdress) is not null)
                 return BadRequest($"A user with the email address {model.EmailAdress} already exists in our system.");

--- a/webapi/Controllers/GenericController.cs
+++ b/webapi/Controllers/GenericController.cs
@@ -24,7 +24,7 @@ namespace webapi.Controllers
         {
             _context = context;
         }
-        
+
         /// <summary>
         /// Gets a list of all entities of type T.
         /// </summary>
@@ -129,13 +129,13 @@ namespace webapi.Controllers
         {
             return await _context.Set<T>().SingleOrDefaultAsync(e => e.Id == id);
         }
-        
+
     }
 }
 
 
-      //TODO : Put/Patch
-    
+//TODO : Put/Patch
+
 
 
 

--- a/webapi/Controllers/GenericController.cs
+++ b/webapi/Controllers/GenericController.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using webapi.Data;
+using webapi.Entities;
+
+namespace webapi.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class GenericController<T> : ControllerBase where T : class, IEntity
+    {
+        public readonly FilmvisarnaContext _context;
+        public GenericController(FilmvisarnaContext context)
+        {
+            _context = context;
+        }
+
+        // Get routes
+        public async Task<List<T>> GetAllRowsFromTableAsync()
+        {
+            return await _context.Set<T>().ToListAsync();
+        }
+        public async Task<T> GetRowByIdAsync(int id)
+        {
+            return await _context.Set<T>().SingleOrDefaultAsync(e => e.Id == id);
+        }
+        [HttpGet]
+        public async Task<ActionResult<List<T>>> GetAll()
+        {
+            var entities = await GetAllRowsFromTableAsync();
+            return Ok(entities);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<List<T>>> GetById(int id)
+        {
+            var entity = await GetRowByIdAsync(id);
+            return Ok(entity);
+        }
+
+        // Post route
+        [HttpPost()]
+        public async Task<ActionResult<T>> Post(T entity)
+        {
+            _context.Set<T>().Add(entity);
+            await _context.SaveChangesAsync();
+            return Ok();
+        }
+
+        // Delete route 
+        [HttpDelete("{id}")]
+        public async Task<ActionResult<T>> DeleteById(int id)
+        {
+            var entity = await GetRowByIdAsync(id);
+            _context.Remove(entity);
+            
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateException /* ex */)
+            {
+                // Log the error (uncomment ex variable name and write a log.
+                return Conflict();
+            }
+
+            return NoContent();
+
+        }
+
+    }
+
+}

--- a/webapi/Controllers/GenericController.cs
+++ b/webapi/Controllers/GenericController.cs
@@ -16,35 +16,71 @@ namespace webapi.Controllers
         }
 
         // Get routes
-        public async Task<List<T>> GetAllRowsFromTableAsync()
-        {
-            return await _context.Set<T>().ToListAsync();
-        }
+
         public async Task<T> GetRowByIdAsync(int id)
         {
+
             return await _context.Set<T>().SingleOrDefaultAsync(e => e.Id == id);
         }
         [HttpGet]
         public async Task<ActionResult<List<T>>> GetAll()
         {
-            var entities = await GetAllRowsFromTableAsync();
-            return Ok(entities);
+            try
+            {
+                var entities = await _context.Set<T>().ToListAsync();
+                if (entities == null || !entities.Any())
+                {
+                    return NotFound();
+                }
+
+                return Ok(entities);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                return StatusCode(500, "Internal Server Error");
+            }
+
         }
 
         [HttpGet("{id}")]
         public async Task<ActionResult<List<T>>> GetById(int id)
         {
-            var entity = await GetRowByIdAsync(id);
-            return Ok(entity);
+            try
+            {
+                var entity = await _context.Set<T>().SingleOrDefaultAsync(e => e.Id == id);
+                if (entity == null)
+                {
+                    return NotFound();
+                }
+                return Ok(entity);
+            }
+
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                return StatusCode(500, "Internal Server Error");
+            }
+
         }
 
         // Post route
+        // TODO : Duplicate Entries. MySQL throws "Duplicate Entries" when setting Unique constraint. Easiest way to handle it.
+        // Otherwise AnyAsync, but has its limits.
         [HttpPost()]
         public async Task<ActionResult<T>> Post(T entity)
         {
-            _context.Set<T>().Add(entity);
-            await _context.SaveChangesAsync();
-            return Ok();
+            try
+            {
+                _context.Set<T>().Add(entity);
+                await _context.SaveChangesAsync();
+                return CreatedAtAction(nameof(GetById), new { id = entity.Id }, entity);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                return StatusCode(500, "Internal Server Error");
+            }
         }
 
         // Delete route 
@@ -53,7 +89,7 @@ namespace webapi.Controllers
         {
             var entity = await GetRowByIdAsync(id);
             _context.Remove(entity);
-            
+
             try
             {
                 await _context.SaveChangesAsync();

--- a/webapi/Controllers/GenericController.cs
+++ b/webapi/Controllers/GenericController.cs
@@ -5,23 +5,30 @@ using webapi.Entities;
 
 namespace webapi.Controllers
 {
+
+    /// <summary>
+    /// A generic controller for performing basic CRUD operations (no joins) on entities of type T.
+    /// </summary>
+    /// <typeparam name="T">The entity type.</typeparam>
     [Route("api/[controller]")]
     [ApiController]
     public class GenericController<T> : ControllerBase where T : class, IEntity
     {
         public readonly FilmvisarnaContext _context;
+
+        /// <summary>
+        /// Initializes a new instance of the CrudController class with a database context.
+        /// </summary>
+        /// <param name="context">The database context.</param>
         public GenericController(FilmvisarnaContext context)
         {
             _context = context;
         }
-
-        // Get routes
-
-        public async Task<T> GetRowByIdAsync(int id)
-        {
-
-            return await _context.Set<T>().SingleOrDefaultAsync(e => e.Id == id);
-        }
+        
+        /// <summary>
+        /// Gets a list of all entities of type T.
+        /// </summary>
+        /// <returns> An ActionResult containing a list of entities, or NotFound if none found.</returns>
         [HttpGet]
         public async Task<ActionResult<List<T>>> GetAll()
         {
@@ -40,33 +47,38 @@ namespace webapi.Controllers
                 Console.WriteLine(ex.Message);
                 return StatusCode(500, "Internal Server Error");
             }
-
         }
 
+        /// <summary>
+        /// Gets an entity of type T by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the entity to retrieve.</param>
+        /// <returns>An ActionResult containing the entity, or NotFound if not found.</returns>
         [HttpGet("{id}")]
         public async Task<ActionResult<List<T>>> GetById(int id)
         {
             try
             {
                 var entity = await _context.Set<T>().SingleOrDefaultAsync(e => e.Id == id);
+
                 if (entity == null)
                 {
                     return NotFound();
                 }
                 return Ok(entity);
             }
-
             catch (Exception ex)
             {
                 Console.WriteLine(ex.Message);
                 return StatusCode(500, "Internal Server Error");
             }
-
         }
 
-        // Post route
-        // TODO : Duplicate Entries. MySQL throws "Duplicate Entries" when setting Unique constraint. Easiest way to handle it.
-        // Otherwise AnyAsync, but has its limits.
+        /// <summary>
+        /// Creates a new entity of type T.
+        /// </summary>
+        /// <param name="entity">The entity to create.</param>
+        /// <returns>An ActionResult containing the created entity, or an error status code if unsuccessful.</returns>
         [HttpPost()]
         public async Task<ActionResult<T>> Post(T entity)
         {
@@ -83,27 +95,47 @@ namespace webapi.Controllers
             }
         }
 
-        // Delete route 
+        /// <summary>
+        /// Deletes an entity of type T by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the entity to delete.</param>
+        /// <returns>An ActionResult with a success status code if the entity is deleted, or NotFound if not found.</returns>
         [HttpDelete("{id}")]
         public async Task<ActionResult<T>> DeleteById(int id)
         {
-            var entity = await GetRowByIdAsync(id);
-            _context.Remove(entity);
-
             try
             {
+                var entity = await GetByIdAsync(id);
+                if (entity == null)
+                {
+                    return NotFound();
+                }
+                _context.Remove(entity);
                 await _context.SaveChangesAsync();
+                return NoContent();
             }
-            catch (DbUpdateException /* ex */)
+            catch (Exception ex)
             {
-                // Log the error (uncomment ex variable name and write a log.
-                return Conflict();
+                Console.WriteLine(ex.Message);
+                return StatusCode(500, "Internal Server Error");
             }
-
-            return NoContent();
-
         }
-
+        /// <summary>
+        /// Gets an entity of type T by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the entity to retrieve.</param>
+        /// <returns>An ActionResult containing the entity, or NotFound if not found.</returns>
+        public async Task<T> GetByIdAsync(int id)
+        {
+            return await _context.Set<T>().SingleOrDefaultAsync(e => e.Id == id);
+        }
+        
     }
-
 }
+
+
+      //TODO : Put/Patch
+    
+
+
+

--- a/webapi/Controllers/GenresController.cs
+++ b/webapi/Controllers/GenresController.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using webapi.Data;
+using webapi.Entities;
+
+namespace webapi.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class GenresController : GenericController<Genre>
+    {
+        public GenresController(FilmvisarnaContext context) : base(context)
+        {
+        }
+    }
+}

--- a/webapi/Controllers/MoviesController.cs
+++ b/webapi/Controllers/MoviesController.cs
@@ -3,38 +3,37 @@ using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using webapi.Data;
+using webapi.Entities;
 
 namespace webapi.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    public class MoviesController : ControllerBase
+    public class MoviesController : GenericController<Movie>
     {
-        private readonly FilmvisarnaContext _context;
-
-        public MoviesController(FilmvisarnaContext context)
+        public MoviesController(FilmvisarnaContext context) : base(context)
         {
-            _context = context;
         }
 
         //Get a detailed list of all movies
+        [Route("detailed")]
         [HttpGet()]
         public async Task<IActionResult> ListAll()
         {
-            var result = await _context.movies     
+            var result = await _context.movies
                 .Select(v => new
-                {   
+                {
                     Id = v.Id,
-                    Movie = v.Name,   
+                    Movie = v.Name,
                     TrailerURL = v.TrailerURL,
                     Genre = v.MoviesXGenres.Select(mxg => mxg.Genre.Name).FirstOrDefault(),
                     Actors = JObject.Parse(v.Description)["actors"].ToObject<List<string>>(),
-                    Director = JObject.Parse(v.Description)["director"].ToString(),      
-                    Description = JObject.Parse(v.Description)["description"].ToString(), 
-                    ProductionYear = JObject.Parse(v.Description)["productionYear"].ToString(), 
+                    Director = JObject.Parse(v.Description)["director"].ToString(),
+                    Description = JObject.Parse(v.Description)["description"].ToString(),
+                    ProductionYear = JObject.Parse(v.Description)["productionYear"].ToString(),
                     ProductionCountries = JObject.Parse(v.Description)["productionCountries"].ToObject<List<string>>(),
                     Language = JObject.Parse(v.Description)["language"].ToString(),
-                    Subtitles = JObject.Parse(v.Description)["subtitles"].ToString(),                
+                    Subtitles = JObject.Parse(v.Description)["subtitles"].ToString(),
                     Duration = v.Duration,
                     AgeLimit = v.AgeLimit,
                     Images = JObject.Parse(v.Description)["images"].ToObject<List<string>>()
@@ -45,22 +44,22 @@ namespace webapi.Controllers
             return Ok(result);
         }
         //Get detailed movie view of chosen ID
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetById(int id)
+        [HttpGet("detailed/{id}")]
+        public async Task<IActionResult> GetDetailedMovieById(int id)
         {
-            var result = await _context.movies     
+            var result = await _context.movies
                 .Select(v => new
-                {   
+                {
                     Id = v.Id,
-                    Movie = v.Name,   
+                    Movie = v.Name,
                     Genre = v.MoviesXGenres.Select(mxg => mxg.Genre.Name).FirstOrDefault(),
                     Actors = JObject.Parse(v.Description)["actors"].ToObject<List<string>>(),
-                    Director = JObject.Parse(v.Description)["director"].ToString(),      
-                    Description = JObject.Parse(v.Description)["description"].ToString(), 
-                    ProductionYear = JObject.Parse(v.Description)["productionYear"].ToString(), 
+                    Director = JObject.Parse(v.Description)["director"].ToString(),
+                    Description = JObject.Parse(v.Description)["description"].ToString(),
+                    ProductionYear = JObject.Parse(v.Description)["productionYear"].ToString(),
                     ProductionCountries = JObject.Parse(v.Description)["productionCountries"].ToObject<List<string>>(),
                     Language = JObject.Parse(v.Description)["language"].ToString(),
-                    Subtitles = JObject.Parse(v.Description)["subtitles"].ToString(),                
+                    Subtitles = JObject.Parse(v.Description)["subtitles"].ToString(),
                     Duration = v.Duration,
                     AgeLimit = v.AgeLimit,
                     Images = JObject.Parse(v.Description)["images"].ToObject<List<string>>()

--- a/webapi/Controllers/MoviesController.cs
+++ b/webapi/Controllers/MoviesController.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using webapi.Data;
 
-namespace YourNamespace.Controllers
+namespace webapi.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]

--- a/webapi/Controllers/ScreeningsController.cs
+++ b/webapi/Controllers/ScreeningsController.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Linq;
 using webapi.Data;
 using System.Globalization;
 
-namespace YourNamespace.Controllers
+namespace webapi.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]

--- a/webapi/Controllers/ScreeningsController.cs
+++ b/webapi/Controllers/ScreeningsController.cs
@@ -4,31 +4,32 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using webapi.Data;
 using System.Globalization;
+using webapi.Entities;
 
 namespace webapi.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    public class ScreeningsController : ControllerBase
+    public class ScreeningsController : GenericController<Screening>
     {
-        private readonly FilmvisarnaContext _context;
+        public ScreeningsController(FilmvisarnaContext context) : base(context)
+        {
+        }
         private static CultureInfo sv = new("sv-SE");
+
         private static string GetDateTime(DateTime dateTime) => dateTime.ToLocalTime().ToString("f", sv);
         private static string GetAbbrevDayOfWeek(DateTime dateTime) => dateTime.ToLocalTime().ToString("f", sv).Substring(0, 3);
         private static string GetDayAndMonth(DateTime dateTime) => dateTime.ToLocalTime().ToString("m", sv);
         private static string GetTime(DateTime dateTime) => dateTime.ToLocalTime().ToString("t", sv);
 
-        public ScreeningsController(FilmvisarnaContext context)
-        {
-            _context = context;
-        }
+
 
         //Get every screening available for one specific movie
         // 
         //          Theater Join is not optimized !!
         [HttpGet("mov{movieId}/")]
         public async Task<IActionResult> GetMovieScreenings(int movieId)
-        {   
+        {
             var movieInfo = await _context.movies
                 .Where(m => m.Id == movieId)
                 .Select(m => new
@@ -96,8 +97,8 @@ namespace webapi.Controllers
                     BookedSeats = v.Bookings
                         .SelectMany(b => b.BookingXSeats)
                         .Select(bxs => new
-                        {                    
-                            SeatId = bxs.SeatId,      
+                        {
+                            SeatId = bxs.SeatId,
                             Seat = bxs.Seat.seat,
                             Row = bxs.Seat.Row
                         })

--- a/webapi/Controllers/ScreeningsController.cs
+++ b/webapi/Controllers/ScreeningsController.cs
@@ -27,7 +27,7 @@ namespace webapi.Controllers
         //Get every screening available for one specific movie
         // 
         //          Theater Join is not optimized !!
-        [HttpGet("mov{movieId}/")]
+        [HttpGet("movie/{movieId}/")]
         public async Task<IActionResult> GetMovieScreenings(int movieId)
         {
             var movieInfo = await _context.movies

--- a/webapi/Controllers/ScreeningsController.cs
+++ b/webapi/Controllers/ScreeningsController.cs
@@ -82,7 +82,7 @@ namespace webapi.Controllers
         }
 
 
-        [HttpGet("{id}")]
+        [HttpGet("bookedseats/{id}")]
         public async Task<IActionResult> GetBookedSeatsForScreening(int id)
         {
             var result = await _context.screenings

--- a/webapi/Controllers/TheatersController.cs
+++ b/webapi/Controllers/TheatersController.cs
@@ -13,7 +13,7 @@ namespace webapi.Controllers
         {
         }
 
-        [HttpGet("{id}")]
+        [HttpGet("detailed/{id}")]
         public async Task<IActionResult> GetDetailedTheaterById(int id)
         {
             var result = await _context.theaters

--- a/webapi/Controllers/TheatersController.cs
+++ b/webapi/Controllers/TheatersController.cs
@@ -1,22 +1,20 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using webapi.Data;
+using webapi.Entities;
 
 namespace webapi.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    public class TheatersController : ControllerBase
+    public class TheatersController : GenericController<Theater>
     {
-        private readonly FilmvisarnaContext _context;
-
-        public TheatersController(FilmvisarnaContext context)
+        public TheatersController(FilmvisarnaContext context) : base(context)
         {
-            _context = context;
         }
 
         [HttpGet("{id}")]
-        public async Task<IActionResult> GetById(int id)
+        public async Task<IActionResult> GetDetailedTheaterById(int id)
         {
             var result = await _context.theaters
                 .Where(t => t.Id == id)

--- a/webapi/Controllers/TheatersController.cs
+++ b/webapi/Controllers/TheatersController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using webapi.Data;
 
-namespace YourNamespace.Controllers
+namespace webapi.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]

--- a/webapi/Controllers/UsersController.cs
+++ b/webapi/Controllers/UsersController.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using webapi.Data;
+using webapi.Entities;
+
+namespace webapi.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class UsersController : GenericController<User>
+    {
+        public UsersController(FilmvisarnaContext context) : base(context)
+        {
+        }
+    }
+}

--- a/webapi/Entities/Booking.cs
+++ b/webapi/Entities/Booking.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace webapi.Entities;
 
-public class Booking
+public class Booking: IEntity
 {
    [Column("BookingId")]
    public int Id { get; set; }

--- a/webapi/Entities/Genre.cs
+++ b/webapi/Entities/Genre.cs
@@ -2,11 +2,11 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace webapi.Entities;
 
-public class Genre
-{   
+public class Genre: IEntity
+{
     [Column("GenreId")]
     public int Id { get; set; }
-    public string Name {get; set;}
+    public string Name { get; set; }
     // Navigation properties
     public ICollection<MovieXGenre> MoviesXGenres { get; set; }
 }

--- a/webapi/Entities/IEntity.cs
+++ b/webapi/Entities/IEntity.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace webapi.Entities
+{
+    public interface IEntity
+    {
+        public int Id { get; set; }
+    }
+}

--- a/webapi/Entities/Movie.cs
+++ b/webapi/Entities/Movie.cs
@@ -4,7 +4,8 @@ using System.Text.Json;
 
 namespace webapi.Entities;
 
-public class Movie {
+public class Movie: IEntity 
+{
     
     [Column("MovieId")]
     public int Id { get; set; }

--- a/webapi/Entities/Screening.cs
+++ b/webapi/Entities/Screening.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace webapi.Entities;
 
-public class Screening
+public class Screening: IEntity
 {
    [Column("ScreeningId")]
    public int Id { get; set; }

--- a/webapi/Entities/Theater.cs
+++ b/webapi/Entities/Theater.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace webapi.Entities;
 
-public class Theater
+public class Theater: IEntity
 {
     [Column("TheaterId")]
     public int Id { get; set; }

--- a/webapi/Entities/User.cs
+++ b/webapi/Entities/User.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace webapi.Entities;
 
-public class User
+public class User: IEntity
 {
 [Column("UserId")]
 public int Id { get; set; }


### PR DESCRIPTION
- Alla controllers ärver nu från en generisk controller som implementerar basic CRUD för alla tables (inga joins i generic!)
- GET, POST and DELETE funkar, PUT får implementeras senare. 
- Specifika endpoints (joins osv) ligger kvar i respektive controller. 
- Fick ändra namn på vissa specifika endpoints i backenden, och även då i frontendsen så att fetch funkar som det ska. 

Detta ger oss ett smidigt sätt att utföra enklare CRUD - hämta, ta bort eller lägga till rader i vald table, och vi behöver inte upprepa oss så mycket i varje controller 