### PR TITLE
Fixade bugg med att hämta actors

### DIFF
--- a/WebReact/src/views/MovieView.jsx
+++ b/WebReact/src/views/MovieView.jsx
@@ -76,7 +76,7 @@ function MovieView() {
 	/// MovieCast
 	const MovieCast = () => {
 		let actors = movies[idx].actors.map((actor) => 
-			<p className="d-inline">{actor}, </p>
+			<p key={actor.id} className="d-inline"> {actor}, </p>
 		);
 
 			return actors;


### PR DESCRIPTION
Min sida krascha när den skulle läsa in actors, man hade glömt ge den en key som sorterar på actors.id vilket jag la till och då funkar allt perfekt. 